### PR TITLE
Lesson 2 - Vector Data I/O in Python: Missing words

### DIFF
--- a/source/notebooks/L2/00-data-io.ipynb
+++ b/source/notebooks/L2/00-data-io.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "In geopandas, we use a generic function [from_file()](http://geopandas.org/reference.html#geopandas.GeoDataFrame.to_file) for reading in different data formats. In the bacground, Geopandas uses [fiona.open()](https://fiona.readthedocs.io/en/latest/fiona.html#fiona.open) when reading in data. Esri Shapefile is the default file format. For other file formats we need to specify which driver to use for reading in the data. \n",
     "\n",
-    "You can check supported through geopandas, or directly from fiona: "
+    "You can check supported format drivers through geopandas, or directly from fiona: "
    ]
   },
   {


### PR DESCRIPTION
Missing words on row 22
I don't know what words are meant to be there - maybe "format drivers" or "data formats" ?