### PR TITLE
Add Google Analytics ID

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,6 +75,7 @@ html_theme_options = {
     "repository_url": "https://github.com/Automating-GIS-processes/site/",
     "use_edit_page_button": True,
     "use_repository_button": True,
+    "google_analytics_id": "UA-88382509-1",
 }
 
 nb_execution_mode = "force"


### PR DESCRIPTION
@christophfink Hi! I happened to check Google Analytics statistics for different websites, and noticed that the most recent version of AutoGIS does not anymore seem to be tracking site visits. Hence, added here the ID. 